### PR TITLE
doc: correct readme usage instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To enable these database limit validations globally:
 
 ```ruby
 class ApplicationRecord < ActiveRecord::Base
-  include Limitable::Base
+  extend Limitable::Base
 
   # ...
 end


### PR DESCRIPTION
- Limitable::Base should be extended not included