### PR TITLE
chore(release): trigger releases on workflow_dispatch

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,9 +1,9 @@
 name: cd
 on:
-  push:
-    branches: [main]
+  workflow_dispatch:
 jobs:
   semantic-release:
+    if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Previously, `semantic-release` would run on every push to the main branch. This moves things in a more "stable" direction and allow for patch/feature accumulation between releases.

